### PR TITLE
Fixed compare typo on motion sensor state.

### DIFF
--- a/adt-pulse-mqtt/package-lock.json
+++ b/adt-pulse-mqtt/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-adt-mqtt",
-  "version": "2.3.3",
+  "version": "2.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/adt-pulse-mqtt/package.json
+++ b/adt-pulse-mqtt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-adt-mqtt",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Home Assistant ADT Pulse Bridge using MQTT",
   "author": "ADT Pulse MQTT Team",
   "main": "server.js",

--- a/adt-pulse-mqtt/server.js
+++ b/adt-pulse-mqtt/server.js
@@ -152,7 +152,7 @@ myAlarm.onZoneUpdate(
 
       if (device.tags.includes("motion")) {
         contactType="motion";
-        contactValue = (device.states == "devStatOK")? "inactive":"active";
+        contactValue = (device.state == "devStatOK")? "inactive":"active";
       }
        sm_dev_zone_state_topic=smartthings_topic+"/"+device.name+"/"+contactType+"/cmd";
     }


### PR DESCRIPTION
Fixed typo reported on #38 where `device.states` was used instead of `device.state` which prevents proper reporting of motion sensor state to Smartthings.